### PR TITLE
Fix user provider re-rendering issue

### DIFF
--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -74,6 +74,7 @@ export function UserProvider({
 
   const { rpcUrl } = value;
   const wallet = useWallet();
+  const publicKey = wallet?.publicKey ? wallet.publicKey.toBase58() : '';
   useEffect(() => {
     const setAnchorProvider = async () => {
       try {
@@ -106,7 +107,7 @@ export function UserProvider({
     };
 
     setAnchorProvider();
-  }, [rpcUrl, wallet]);
+  }, [rpcUrl, publicKey]);
 
   if (!providerApp) {
     return <Spinner />;


### PR DESCRIPTION
Update the dependency in the useEffect hook to include the public key, ensuring the UserProvider re-renders correctly when the wallet's public key changes.